### PR TITLE
Fixed validation of zero value

### DIFF
--- a/src/Kdyby/Replicator/Container.php
+++ b/src/Kdyby/Replicator/Container.php
@@ -414,7 +414,7 @@ class Container extends Nette\Forms\Container
 		$rows = array();
 		$subComponents = array_flip($subComponents);
 		foreach ($httpData as $item) {
-			$rows[] = array_filter(array_diff_key($item, $subComponents)) ?: FALSE;
+			$rows[] = array_filter(array_diff_key($item, $subComponents), 'strlen') ?: FALSE;
 		}
 
 		return count(array_filter($rows));


### PR DESCRIPTION
There was a problem with the validation. It does not accept zero value because array_filter without callback removes all entries of input equal to FALSE.
