### PR TITLE
Adding and removing stops onSuccess event

### DIFF
--- a/src/Kdyby/Replicator/Container.php
+++ b/src/Kdyby/Replicator/Container.php
@@ -517,6 +517,7 @@ class Container extends Nette\Forms\Container
 					callback($callback)->invoke($replicator, $button->parent);
 				}
 				$replicator->remove($button->parent);
+				$button->getForm()->onSuccess = array();
 			};
 			return $_this;
 		});
@@ -536,6 +537,7 @@ class Container extends Nette\Forms\Container
 				if (is_callable($callback)) {
 					callback($callback)->invoke($replicator, $newContainer);
 				}
+				$button->getForm()->onSuccess = array();
 			};
 			return $_this;
 		});


### PR DESCRIPTION
I usually add _redirect after form submit_ into `onSuccess[]` event. But when you click button with `addCreateOnClick` or `addRemoveOnClick`, you probably never want any final processing of the form. This would also remove requirement to attach final processing to `onClick` event of primary send button.
