### PR TITLE
Fixed counting filled rows for Container in Replicator

### DIFF
--- a/src/Kdyby/Replicator/Container.php
+++ b/src/Kdyby/Replicator/Container.php
@@ -421,8 +421,8 @@ class Container extends Nette\Forms\Container
 		$subComponents = array_flip($subComponents);
 		foreach ($httpData as $item) {
 			$rows[] = array_filter(array_diff_key($item, $subComponents), function($value) {
-				if(is_array($value)) {
-					return count($value = array_filter($value, 'strlen')) > 0;
+				if (is_array($value)) {
+					return count(array_filter($value, 'strlen')) > 0;
 				}
 				return strlen($value);
 			}) ?: FALSE;


### PR DESCRIPTION
When I have Container in Replicator, it throws function countFilledWithout with exception cause strlen is not callable to array.
