### PR TITLE
Using Replicator with standalone forms does not fire attached

### DIFF
--- a/src/Kdyby/Replicator/Container.php
+++ b/src/Kdyby/Replicator/Container.php
@@ -63,6 +63,7 @@ class Container extends Nette\Forms\Container
 	{
 		parent::__construct();
 		$this->monitor('Nette\Application\UI\Presenter');
+		$this->monitor('Nette\Forms\Form');
 
 		try {
 			$this->factoryCallback = Callback::closure($factory);
@@ -98,7 +99,11 @@ class Container extends Nette\Forms\Container
 	{
 		parent::attached($obj);
 
-		if (!$obj instanceof Nette\Application\UI\Presenter) {
+		if (
+			!$obj instanceof Nette\Application\UI\Presenter
+			&&
+			$this->form instanceof Nette\Application\UI\Form
+		) {
 			return;
 		}
 

--- a/tests/KdybyTests/Replicator/Container.phpt
+++ b/tests/KdybyTests/Replicator/Container.phpt
@@ -222,6 +222,12 @@ class ContainerTest extends Tester\TestCase
 		return $config->createContainer();
 	}
 
+
+	// TODO: add tests using standalone \Nette\Forms\Form and not the UI\Form.
+	// https://github.com/Kdyby/Replicator/issues/40
+	// The Replicator can't be used with standalone \Nette\Forms\Form (so without the UI\Form).
+	// Problem is that attached is not triggered, so values from Request are not populated to the container.
+
 }
 
 


### PR DESCRIPTION
Hi,

the Replicator can't be used with standalone \Nette\Forms\Form (so without the UI\Form).
Problem is that attached is not triggered, so values from Request are not populated to the container.