### PR TITLE
default values and createdefault error

### DIFF
--- a/src/Kdyby/Replicator/Container.php
+++ b/src/Kdyby/Replicator/Container.php
@@ -275,8 +275,8 @@ class Container extends Nette\Forms\Container
 		}
 
 		if (!$this->getForm()->isSubmitted()) {
-			foreach (range(0, $this->createDefault - 1) as $key) {
-				$this->createOne($key);
+			while (iterator_count($this->getContainers()) < $this->createDefault) {
+				$this->createOne();
 			}
 
 		} elseif ($this->forceDefault) {


### PR DESCRIPTION
# I Have code
``` php
        $directors = $form->addDynamic(
            'directors',
            function (Container $cont) {
               $container->addSelect('id','director', $this->getDirectorList() )
                ...
             },1,true
        );
        ...
        $defaults = []
        foreach ($directors as $director)
        {
             $defaults['directors'][] = ['id' => $director['id']];
        }

        $form->setDefaults($defaults);
```
# Expecting 
Form with selects count == count($directors) prefilled or 1 empty if count($directors) == 0
# Getting
InvalidArgumentException("Container with name 0 already exists.");