### PR TITLE
Fix type annotations

### DIFF
--- a/src/Replicator/Container.php
+++ b/src/Replicator/Container.php
@@ -99,7 +99,7 @@ class Container extends Nette\Forms\Container
 
 
 	/**
-	 * @return Iterator|Nette\Forms\Container[]
+	 * @return Iterator<Nette\Forms\Container>
 	 */
 	public function getContainers(bool $recursive = FALSE): Iterator
 	{
@@ -108,7 +108,7 @@ class Container extends Nette\Forms\Container
 
 
 	/**
-	 * @return Iterator|Nette\Forms\Controls\SubmitButton[]
+	 * @return Iterator<Nette\Forms\ISubmitterControl>
 	 */
 	public function getButtons(bool $recursive = FALSE): Iterator
 	{


### PR DESCRIPTION
When validating my app using Psalm, I get the following error:

    ERROR: PossiblyInvalidArgument - app/forms/TeamFormFactory.php:63:26 - Argument 1 of iterator_count expects Traversable, possibly different type Iterator|array<array-key, Nette\Forms\Container> provided
                return iterator_count($replicator->getContainers()) <= $maxMembers;

Since Nette\ComponentModel\Container::getComponents only returns Iterator, let’s fix the annotations using generics.