### PR TITLE
ci: fix failing CI at #65

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - "8.1"
                     - "8.2"
                     - "8.3"
                     - "8.4"
@@ -42,7 +41,6 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - "8.1"
                     - "8.2"
                     - "8.3"
                     - "8.4"
@@ -75,7 +73,6 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - "8.1"
                     - "8.2"
                     - "8.3"
                     - "8.4"
@@ -107,7 +104,6 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - "8.1"
                     - "8.2"
                     - "8.3"
                     - "8.4"
@@ -139,7 +135,6 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - "8.1"
                     - "8.2"
                     - "8.3"
                     - "8.4"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 		"nette/bootstrap": "^3.0",
 		"nette/di": "^3.0",
 		"tracy/tracy": "^2.6",
-		"nette/tester": "^2.2",
+		"nette/tester": "^2.5",
 		"php-parallel-lint/php-console-highlighter": "^1.0",
 		"php-parallel-lint/php-parallel-lint": "^1.4",
 		"phpstan/phpstan": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,14 @@
 		"nette/application": "^3.0",
 		"nette/bootstrap": "^3.0",
 		"nette/di": "^3.0",
-		"tracy/tracy": "^2.6",
+		"tracy/tracy": "^2.10.8",
 		"nette/tester": "^2.5",
 		"php-parallel-lint/php-console-highlighter": "^1.0",
 		"php-parallel-lint/php-parallel-lint": "^1.4",
 		"phpstan/phpstan": "^2.1",
 		"rector/rector": "^2.0",
-		"symplify/easy-coding-standard": "^12.5"
+		"symplify/easy-coding-standard": "^12.5",
+		"nette/neon": "^3.4.4"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 	},
 	"require": {
 		"php": ">= 8.2",
-		"nette/forms": "^3.2",
+		"nette/forms": "^3.2.3",
 		"nette/utils": "^3.0 || ^4.0"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 		"issues": "https://github.com/Kdyby/FormsReplicator/issues"
 	},
 	"require": {
-		"php": ">=8.1",
+		"php": ">= 8.2",
 		"nette/forms": "^3.2",
 		"nette/utils": "^3.0 || ^4.0"
 	},

--- a/rector.php
+++ b/rector.php
@@ -18,6 +18,6 @@ return RectorConfig
 		->withRootFiles()
 		->withParallel()
 		->withPhpSets(
-			php81: true,
+			php82: true,
 		)
 ;


### PR DESCRIPTION
Changes: 

- Set minimal PHP version to 8.2 (Here is incompatibility with `iterator_to_array()` argument types).
- Set minimal `nette/forms` version to 3.2.3 (Here is incompatibility with `Nette\Forms\Container::setValues()` signature.)
- Update minimal version of dev packages (for compatibility with 8.4):
    - `nette/tester`
    - `tracy/tracy`
    - `neon/neon`

All CI jobs are now passed, see jakubboucek#1 (created for run Action jobs only).