### PR TITLE
git: Prevent export dev-only files to package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,9 @@
+.editorconfig export-ignore
 .gitattributes export-ignore
+.github export-ignore
 .gitignore export-ignore
-.travis.yml export-ignore
 docs export-ignore
+ecs.php export-ignore
+phpstan.dist.neon export-ignore
+rector.php export-ignore
 tests export-ignore


### PR DESCRIPTION
This pull request updates the `.gitattributes` file to refine the list of files and directories excluded from export operations. The most important changes include adding new entries for exclusion and removing an outdated entry.

Updates to export-ignore entries in `.gitattributes`:

* Added `.editorconfig`, `.github`, `ecs.php`, `phpstan.dist.neon`, and `rector.php` to the list of files/directories excluded from export.
* Removed `.travis.yml` from the export-ignore list, likely because it is no longer relevant or present in the repository.