### PR TITLE
Composer: Add scripts for manual run each CI's jobs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,5 +55,13 @@
 		"branch-alias": {
 			"dev-master": "3.0-dev"
 		}
+	},
+	"scripts": {
+		"lint": "php ./vendor/bin/parallel-lint -e php,phpt --exclude ./.git --exclude ./vendor .",
+		"phpstan": "php ./vendor/bin/phpstan --ansi",
+		"ecs": "php ./vendor/bin/ecs",
+		"rector": "php ./vendor/bin/rector process --dry-run --ansi",
+		"test": "php ./vendor/bin/tester -s -p php --colors 1 -C ./tests/Replicator",
+		"ci": "[\"@lint\", \"@phpstan\", \"@ecs\", \"@rector\", \"@test\"]"
 	}
 }


### PR DESCRIPTION
This pull request introduces a set of scripts to the `composer.json` file, streamlining development and CI workflows. These scripts include commands for linting, static analysis, coding standards checks, code refactoring, and running tests.

### Added scripts in `composer.json`:

* **Linting**: Added a `lint` script to check PHP files for syntax errors, excluding `.git` and `vendor` directories.
* **Static Analysis**: Added a `phpstan` script for static code analysis using PHPStan.
* **Coding Standards**: Added an `ecs` script to enforce coding standards with EasyCodingStandard.
* **Code Refactoring**: Added a `rector` script for code refactoring with Rector in dry-run mode.
* **Testing and CI**: Added `test` and `ci` scripts to run tests and execute all CI-related tasks, respectively.