### PR TITLE
Fix CI by applying RemoveReflectionSetAccessibleCallsRector

### DIFF
--- a/src/Replicator/Container.php
+++ b/src/Replicator/Container.php
@@ -282,7 +282,6 @@ class Container extends Nette\Forms\Container
 		// reflection is required to hack form groups
 		$groupRefl = new ReflectionClass(Nette\Forms\ControlGroup::class);
 		$controlsProperty = $groupRefl->getProperty('controls');
-		$controlsProperty->setAccessible(TRUE);
 
 		// walk groups and clean then from removed components
 		$affected = [];


### PR DESCRIPTION
Rector will now try to remove `ReflectionProperty::setAccessible()` call since it is not needed since PHP 8.1:
https://www.php.net/manual/en/reflectionproperty.getvalue.php

We already require PHP 8.2 so this is fine.
