### PR TITLE
Add PHP 8.5 CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
                     - "8.2"
                     - "8.3"
                     - "8.4"
+                    - "8.5"
                 dependencies:
                     - "highest"
         steps:
@@ -45,9 +46,13 @@ jobs:
                     - "8.2"
                     - "8.3"
                     - "8.4"
+                    - "8.5"
                 dependencies:
                     - "lowest"
                     - "highest"
+                exclude:
+                    -   php: "8.5"
+                        dependencies: "lowest"
         steps:
             -   name: ⬇️ Checkout repo
                 uses: actions/checkout@v4
@@ -76,6 +81,7 @@ jobs:
                     - "8.2"
                     - "8.3"
                     - "8.4"
+                    - "8.5"
                 dependencies:
                     - "highest"
         steps:
@@ -106,6 +112,7 @@ jobs:
                     - "8.2"
                     - "8.3"
                     - "8.4"
+                    - "8.5"
                 dependencies:
                     - "highest"
         steps:
@@ -136,9 +143,13 @@ jobs:
                     - "8.2"
                     - "8.3"
                     - "8.4"
+                    - "8.5"
                 dependencies:
                     - "lowest"
                     - "highest"
+                exclude:
+                    -   php: "8.5"
+                        dependencies: "lowest"
         steps:
             -   name: ⬇️ Checkout repo
                 uses: actions/checkout@v4

--- a/src/Replicator/Container.php
+++ b/src/Replicator/Container.php
@@ -141,7 +141,7 @@ class Container extends Nette\Forms\Container
 
 		($this->factoryCallback)($container);
 
-		return $this->created[$container->getName()] = $container;
+		return $this->created[$name] = $container;
 	}
 
 	private function getFirstControlName(): ?string


### PR DESCRIPTION
## Summary

- add PHP 8.5 to every highest-dependency CI job
- retain lowest/highest coverage on PHP 8.2, 8.3, and 8.4
- exclude PHP 8.5 with lowest dependencies because component-model 3.1.x itself emits PHP 8.5 deprecations
- use the already-known non-null component factory name directly instead of re-reading its nullable API type

## Verification

- PHP 8.5 highest dependencies: full Composer CI passes
- lint: 15 files
- PHPStan: no errors with 2.2.7
- ECS and Rector: clean
- Tester 2.6.1: 12 tests pass on PHP 8.5.8
- actionlint: clean

The package runtime constraint remains PHP >= 8.2; this PR expands verified CI coverage without narrowing supported dependency ranges.