### PR TITLE
Upgrade GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
     push:
     pull_request:
 
+permissions:
+    contents: read
+
 jobs:
     parallel-lint:
         name: 🔎 Parallel lint
@@ -20,7 +23,9 @@ jobs:
                     - "highest"
         steps:
             -   name: ⬇️ Checkout repo
-                uses: actions/checkout@v4
+                uses: actions/checkout@v7
+                with:
+                    persist-credentials: false
 
             -   name: 🐘 Setup PHP
                 uses: shivammathur/setup-php@v2
@@ -29,7 +34,7 @@ jobs:
                     coverage: none
 
             -   name: 📥 Install dependencies
-                uses: ramsey/composer-install@v3
+                uses: ramsey/composer-install@4.0.0
                 with:
                     dependency-versions: "${{ matrix.dependencies }}"
 
@@ -55,7 +60,9 @@ jobs:
                         dependencies: "lowest"
         steps:
             -   name: ⬇️ Checkout repo
-                uses: actions/checkout@v4
+                uses: actions/checkout@v7
+                with:
+                    persist-credentials: false
 
             -   name: 🐘 Setup PHP
                 uses: shivammathur/setup-php@v2
@@ -64,7 +71,7 @@ jobs:
                     coverage: none
 
             -   name: 📥 Install dependencies
-                uses: ramsey/composer-install@v3
+                uses: ramsey/composer-install@4.0.0
                 with:
                     dependency-versions: "${{ matrix.dependencies }}"
 
@@ -86,7 +93,9 @@ jobs:
                     - "highest"
         steps:
             -   name: ⬇️ Checkout repo
-                uses: actions/checkout@v4
+                uses: actions/checkout@v7
+                with:
+                    persist-credentials: false
 
             -   name: 🐘 Setup PHP
                 uses: shivammathur/setup-php@v2
@@ -95,7 +104,7 @@ jobs:
                     coverage: none
 
             -   name: 📥 Install dependencies
-                uses: ramsey/composer-install@v3
+                uses: ramsey/composer-install@4.0.0
                 with:
                     dependency-versions: "${{ matrix.dependencies }}"
 
@@ -117,7 +126,9 @@ jobs:
                     - "highest"
         steps:
             -   name: ⬇️ Checkout repo
-                uses: actions/checkout@v4
+                uses: actions/checkout@v7
+                with:
+                    persist-credentials: false
 
             -   name: 🐘 Setup PHP
                 uses: shivammathur/setup-php@v2
@@ -126,7 +137,7 @@ jobs:
                     coverage: none
 
             -   name: 📥 Install dependencies
-                uses: ramsey/composer-install@v3
+                uses: ramsey/composer-install@4.0.0
                 with:
                     dependency-versions: "${{ matrix.dependencies }}"
 
@@ -152,7 +163,9 @@ jobs:
                         dependencies: "lowest"
         steps:
             -   name: ⬇️ Checkout repo
-                uses: actions/checkout@v4
+                uses: actions/checkout@v7
+                with:
+                    persist-credentials: false
 
             -   name: 🐘 Setup PHP
                 uses: shivammathur/setup-php@v2
@@ -161,7 +174,7 @@ jobs:
                     coverage: xdebug
 
             -   name: 📥 Install dependencies
-                uses: ramsey/composer-install@v3
+                uses: ramsey/composer-install@4.0.0
                 with:
                     dependency-versions: "${{ matrix.dependencies }}"
 


### PR DESCRIPTION
## Summary

- upgrade `actions/checkout` from v4 to v7, the latest stable major
- upgrade `ramsey/composer-install` from v3 to 4.0.0, its latest release
- retain `shivammathur/setup-php@v2`, which remains its current major and tracks release 2.37.2
- restrict the workflow token to read-only repository contents
- disable persisted checkout credentials because CI never performs authenticated Git operations

## Runtime compatibility

Checkout v7 and composer-install 4 use the Node 24 action runtime. The workflow runs exclusively on GitHub-hosted `ubuntu-latest` runners, which satisfy their runner requirements.

The composer-install project does not publish a moving `v4` tag, so the workflow references exact release `4.0.0`.

## Verification

- Actionlint passes
- workflow whitespace checks pass
- all five jobs and every PHP/dependency matrix cell execute in this PR
